### PR TITLE
Update ring to 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["lib"]
 [dependencies]
 rust-gmp = "0.5.0"
 rand = "0.4"
-ring = "0.12"
+ring = "0.13"
 
 [dependencies.secp256k1]
 version = "0.9.0"


### PR DESCRIPTION
Following https://github.com/KZen-networks/multi-party-ecdsa/issues/27#issuecomment-408026593 and `cargo doc` failure on this repository:
```
$ cargo +nightly doc
 Documenting ring v0.12.1
    Checking paillier v0.2.0-pre (https://github.com/mortendahl/rust-paillier?branch=dev#0916f46c)
    Checking cryptography-utils v0.1.0 (https://github.com/KZen-networks/cryptography-utils#51adbc95)
error: `[Debug]` cannot be resolved, ignoring it...
   |
note: lint level defined here
  --> /home/roman/.cargo/registry/src/github.com-1ecc6299db9ec823/ring-0.12.1/src/lib.rs:63:5
   |
63 |     warnings,
   |     ^^^^^^^^
   = note: #[forbid(intra_doc_link_resolution_failure)] implied by #[forbid(warnings)]
   = note: the link appears in this line:
           
            themselves through the [`Display`] and [`Debug`] traits, and may provide
                                                    ^^^^^^^
   = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

error: Could not document `ring`.
```

Thanks @GutteApps for fixing the issue!