### PR TITLE
fix Secp256k1Point deserialization

### DIFF
--- a/src/elliptic/curves/secp256_k1.rs
+++ b/src/elliptic/curves/secp256_k1.rs
@@ -534,8 +534,10 @@ impl<'de> Visitor<'de> for Secp256k1PointVisitor {
             let v = map.next_value::<&'de str>()?;
             println!("v = {}", v);
             if key == "x" {
+                println!("key == x");
                 x = String::from(v)
             } else if key == "y" {
+                println!("key == y");
                 y = String::from(v)
             } else {
                 panic!("Serialization failed!")

--- a/src/elliptic/curves/secp256_k1.rs
+++ b/src/elliptic/curves/secp256_k1.rs
@@ -246,7 +246,9 @@ impl<'de> Visitor<'de> for Secp256k1ScalarVisitor {
     }
 
     fn visit_str<E: de::Error>(self, s: &str) -> Result<Secp256k1Scalar, E> {
+        println!("curv.visit_str: s #1 = {:?}", s);
         let v = BigInt::from_str_radix(s, 16).expect("Failed in serde");
+        println!("curv.visit_str: s #2 = {:?}", s);
         Ok(ECScalar::from(&v))
     }
 }

--- a/src/elliptic/curves/secp256_k1.rs
+++ b/src/elliptic/curves/secp256_k1.rs
@@ -511,7 +511,8 @@ impl<'de> Deserialize<'de> for Secp256k1Point {
     where
         D: Deserializer<'de>,
     {
-        deserializer.deserialize_map(Secp256k1PointVisitor)
+        let fields = &["x", "y"];
+        deserializer.deserialize_struct("Secp256k1Point", fields,Secp256k1PointVisitor)
     }
 }
 

--- a/src/elliptic/curves/secp256_k1.rs
+++ b/src/elliptic/curves/secp256_k1.rs
@@ -529,21 +529,18 @@ impl<'de> Visitor<'de> for Secp256k1PointVisitor {
         let mut y = String::new();
         println!("curv: here in secp256k1");
 
-//        while let Some(ref key) = map.next_key::<String>()? {
-//            println!("here in secp256k1 while let");
-//            let v = map.next_value::<&'de str>()?;
-//            println!("v = {}", v);
-//            match key {
-//                "x" => x = String::from(v),
-//                "y" => y = String::from(v),
-//                _ => panic!("Serialization failed!"),
-//            }
-//        }
-
-        let x = match map.next_key::<String>()? {
-            Some(ref k) if k == "x" => map.next_value()?,
-            _ => return Err(de::Error::missing_field("x"))
-        };
+        while let Some(ref key) = map.next_key::<String>()? {
+            println!("curv: here in secp256k1 while let");
+            let v = map.next_value::<&'de str>()?;
+            println!("v = {}", v);
+            if key == "x" {
+                x = String::from(v)
+            } else if key == "y" {
+                y = String::from(v)
+            } else {
+                panic!("Serialization failed!")
+            }
+        }
 
         println!("curv: post while let");
         let bx = BigInt::from_hex(&x);

--- a/src/elliptic/curves/secp256_k1.rs
+++ b/src/elliptic/curves/secp256_k1.rs
@@ -532,7 +532,8 @@ impl<'de> Visitor<'de> for Secp256k1PointVisitor {
         while let Some(ref key) = map.next_key::<String>()? {
             println!("curv: here in secp256k1 while let");
             let v = map.next_value::<String>()?;
-            println!("v = {}", v);
+            println!("curv: v = {}", v);
+            println!("curv: key = {}", key);
             if key == "x" {
                 println!("key == x");
                 x = String::from(v)

--- a/src/elliptic/curves/secp256_k1.rs
+++ b/src/elliptic/curves/secp256_k1.rs
@@ -527,19 +527,25 @@ impl<'de> Visitor<'de> for Secp256k1PointVisitor {
     fn visit_map<E: MapAccess<'de>>(self, mut map: E) -> Result<Secp256k1Point, E::Error> {
         let mut x = String::new();
         let mut y = String::new();
-        println!("here in secp256k1");
+        println!("curv: here in secp256k1");
 
-        while let Some(key) = map.next_key::<&'de str>()? {
-            println!("here in secp256k1 while let");
-            let v = map.next_value::<&'de str>()?;
-            println!("v = {}", v);
-            match key {
-                "x" => x = String::from(v),
-                "y" => y = String::from(v),
-                _ => panic!("Serialization failed!"),
-            }
-        }
+//        while let Some(ref key) = map.next_key::<String>()? {
+//            println!("here in secp256k1 while let");
+//            let v = map.next_value::<&'de str>()?;
+//            println!("v = {}", v);
+//            match key {
+//                "x" => x = String::from(v),
+//                "y" => y = String::from(v),
+//                _ => panic!("Serialization failed!"),
+//            }
+//        }
 
+        let x = match map.next_key::<String>()? {
+            Some(ref k) if k == "x" => map.next_value()?,
+            _ => return Err(de::Error::missing_field("x"))
+        };
+
+        println!("curv: post while let");
         let bx = BigInt::from_hex(&x);
         let by = BigInt::from_hex(&y);
 

--- a/src/elliptic/curves/secp256_k1.rs
+++ b/src/elliptic/curves/secp256_k1.rs
@@ -525,9 +525,12 @@ impl<'de> Visitor<'de> for Secp256k1PointVisitor {
     fn visit_map<E: MapAccess<'de>>(self, mut map: E) -> Result<Secp256k1Point, E::Error> {
         let mut x = String::new();
         let mut y = String::new();
+        println!("here in secp256k1");
 
         while let Some(key) = map.next_key::<&'de str>()? {
+            println!("here in secp256k1 while let");
             let v = map.next_value::<&'de str>()?;
+            println!("v = {}", v);
             match key {
                 "x" => x = String::from(v),
                 "y" => y = String::from(v),

--- a/src/elliptic/curves/secp256_k1.rs
+++ b/src/elliptic/curves/secp256_k1.rs
@@ -246,9 +246,7 @@ impl<'de> Visitor<'de> for Secp256k1ScalarVisitor {
     }
 
     fn visit_str<E: de::Error>(self, s: &str) -> Result<Secp256k1Scalar, E> {
-        println!("curv.visit_str: s #1 = {:?}", s);
         let v = BigInt::from_str_radix(s, 16).expect("Failed in serde");
-        println!("curv.visit_str: s #2 = {:?}", s);
         Ok(ECScalar::from(&v))
     }
 }
@@ -528,26 +526,18 @@ impl<'de> Visitor<'de> for Secp256k1PointVisitor {
     fn visit_map<E: MapAccess<'de>>(self, mut map: E) -> Result<Secp256k1Point, E::Error> {
         let mut x = String::new();
         let mut y = String::new();
-        println!("curv: here in secp256k1");
 
         while let Some(ref key) = map.next_key::<String>()? {
-            println!("curv: here in secp256k1 while let");
-            println!("curv: key #1 = {}", key);
             let v = map.next_value::<String>()?;
-            println!("curv: v = {}", v);
-            println!("curv: key #2 = {}", key);
             if key == "x" {
-                println!("key == x");
                 x = String::from(v)
             } else if key == "y" {
-                println!("key == y");
                 y = String::from(v)
             } else {
                 panic!("Serialization failed!")
             }
         }
 
-        println!("curv: post while let");
         let bx = BigInt::from_hex(&x);
         let by = BigInt::from_hex(&y);
 

--- a/src/elliptic/curves/secp256_k1.rs
+++ b/src/elliptic/curves/secp256_k1.rs
@@ -527,14 +527,12 @@ impl<'de> Visitor<'de> for Secp256k1PointVisitor {
         let mut x = String::new();
         let mut y = String::new();
 
-        while let Some(ref key) = map.next_key::<String>()? {
-            let v = map.next_value::<String>()?;
-            if key == "x" {
-                x = String::from(v)
-            } else if key == "y" {
-                y = String::from(v)
-            } else {
-                panic!("Serialization failed!")
+        while let Some(key) = map.next_key::<&'de str>()? {
+            let v = map.next_value::<&'de str>()?;
+            match key {
+                "x" => x = String::from(v),
+                "y" => y = String::from(v),
+                _ => panic!("Serialization failed!"),
             }
         }
 

--- a/src/elliptic/curves/secp256_k1.rs
+++ b/src/elliptic/curves/secp256_k1.rs
@@ -531,7 +531,7 @@ impl<'de> Visitor<'de> for Secp256k1PointVisitor {
 
         while let Some(ref key) = map.next_key::<String>()? {
             println!("curv: here in secp256k1 while let");
-            let v = map.next_value::<&'de str>()?;
+            let v = map.next_value::<String>()?;
             println!("v = {}", v);
             if key == "x" {
                 println!("key == x");

--- a/src/elliptic/curves/secp256_k1.rs
+++ b/src/elliptic/curves/secp256_k1.rs
@@ -527,12 +527,14 @@ impl<'de> Visitor<'de> for Secp256k1PointVisitor {
         let mut x = String::new();
         let mut y = String::new();
 
-        while let Some(key) = map.next_key::<&'de str>()? {
-            let v = map.next_value::<&'de str>()?;
-            match key {
-                "x" => x = String::from(v),
-                "y" => y = String::from(v),
-                _ => panic!("Serialization failed!"),
+        while let Some(ref key) = map.next_key::<String>()? {
+            let v = map.next_value::<String>()?;
+            if key == "x" {
+                x = String::from(v)
+            } else if key == "y" {
+                y = String::from(v)
+            } else {
+                panic!("Serialization failed!")
             }
         }
 

--- a/src/elliptic/curves/secp256_k1.rs
+++ b/src/elliptic/curves/secp256_k1.rs
@@ -531,9 +531,10 @@ impl<'de> Visitor<'de> for Secp256k1PointVisitor {
 
         while let Some(ref key) = map.next_key::<String>()? {
             println!("curv: here in secp256k1 while let");
+            println!("curv: key #1 = {}", key);
             let v = map.next_value::<String>()?;
             println!("curv: v = {}", v);
-            println!("curv: key = {}", key);
+            println!("curv: key #2 = {}", key);
             if key == "x" {
                 println!("key == x");
                 x = String::from(v)


### PR DESCRIPTION
1. changed `deserialize` to call `deserialize_struct` instead of `deserialize_map` becuase the deserializer needs to know the struct fields. <br>
2. When deserializing into the DB the `visit_map` method crashes when expecting `&str`. Changes that to `String`. Related issue: [https://github.com/serde-rs/serde/issues/1009](https://github.com/serde-rs/serde/issues/1009)