### PR TITLE
Adding global context secp256k1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,8 @@ features = ["serde_support"]
 git = "https://github.com/KZen-networks/rust-gmp"
 
 [dependencies.secp256k1]
-version = "0.12.0"
-features = ["rand", "serde"]
+version = "0.14.0"
+features = ["serde"]
 
 [dependencies.curve25519-dalek]
 version = "1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ rand = "0.6"
 ring = "0.13.5"
 serde = "1.0"
 serde_derive = "1.0"
-serde_json = "1.0"
 merkle = "1.10.0"
 zeroize = "0.5.2"
 sha3 = "0.8.1"
@@ -61,4 +60,8 @@ version = "1.0.1"
 
 [dependencies.cryptoxide]
 version = "0.1.0"
+
+
+[dev-dependencies]
+serde_json = "1.0"
 

--- a/src/elliptic/curves/curve_jubjub.rs
+++ b/src/elliptic/curves/curve_jubjub.rs
@@ -532,7 +532,7 @@ mod tests {
     use arithmetic::traits::Modulo;
     use elliptic::curves::traits::ECPoint;
     use elliptic::curves::traits::ECScalar;
-    use serde_json;
+    extern crate serde_json;
     use BigInt;
     use {FE, GE};
 

--- a/src/elliptic/curves/curve_ristretto.rs
+++ b/src/elliptic/curves/curve_ristretto.rs
@@ -471,7 +471,7 @@ mod tests {
     use arithmetic::traits::Modulo;
     use elliptic::curves::traits::ECPoint;
     use elliptic::curves::traits::ECScalar;
-    use serde_json;
+    extern crate serde_json;
     use BigInt;
     use {FE, GE};
 

--- a/src/elliptic/curves/ed25519.rs
+++ b/src/elliptic/curves/ed25519.rs
@@ -577,7 +577,7 @@ mod tests {
     use arithmetic::traits::Modulo;
     use elliptic::curves::traits::ECPoint;
     use elliptic::curves::traits::ECScalar;
-    use serde_json;
+    extern crate serde_json;
     use BigInt;
     use {FE, GE};
 

--- a/src/elliptic/curves/secp256_k1.rs
+++ b/src/elliptic/curves/secp256_k1.rs
@@ -582,7 +582,7 @@ mod tests {
     use cryptographic_primitives::hashing::traits::Hash;
     use elliptic::curves::traits::ECPoint;
     use elliptic::curves::traits::ECScalar;
-    use serde_json;
+    extern crate serde_json;
 
     #[test]
     fn serialize_sk() {

--- a/src/elliptic/curves/secp256_k1.rs
+++ b/src/elliptic/curves/secp256_k1.rs
@@ -20,7 +20,7 @@ use super::rand::{thread_rng, Rng};
 use super::secp256k1::constants::{
     CURVE_ORDER, GENERATOR_X, GENERATOR_Y, SECRET_KEY_SIZE, UNCOMPRESSED_PUBLIC_KEY_SIZE,
 };
-use super::secp256k1::{PublicKey, Secp256k1, SecretKey};
+use super::secp256k1::{PublicKey, Secp256k1, SecretKey, VerifyOnly};
 use super::traits::{ECPoint, ECScalar};
 use arithmetic::traits::{Converter, Modulo};
 use cryptographic_primitives::hashing::hash_sha256::HSha256;
@@ -35,7 +35,7 @@ use serde::{Deserialize, Deserializer};
 use std::fmt;
 use std::ops::{Add, Mul};
 use std::ptr;
-use std::sync::atomic;
+use std::sync::{atomic, Once};
 use zeroize::Zeroize;
 use BigInt;
 use ErrorKey;
@@ -383,7 +383,7 @@ impl ECPoint<PK, SK> for Secp256k1Point {
         let mut new_point = *self;
         new_point
             .ge
-            .mul_assign(&Secp256k1::new(), &fe[..])
+            .mul_assign(get_context(), &fe[..])
             .expect("Assignment expected");
         new_point
     }
@@ -458,6 +458,15 @@ impl ECPoint<PK, SK> for Secp256k1Point {
             ge: PK::from_slice(&v).unwrap(),
         }
     }
+}
+
+static mut CONTEXT: Option<Secp256k1<VerifyOnly>> = None;
+pub fn get_context() -> &'static Secp256k1<VerifyOnly> {
+    static INIT_CONTEXT: Once = Once::new();
+    INIT_CONTEXT.call_once(|| unsafe {
+        CONTEXT = Some(Secp256k1::verification_only());
+    });
+    unsafe { CONTEXT.as_ref().unwrap() }
 }
 
 impl Hashable for Secp256k1Point {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@ extern crate serde_derive;
 extern crate merkle;
 extern crate ring;
 extern crate serde;
-extern crate serde_json;
 extern crate sha3;
 extern crate zeroize;
 


### PR DESCRIPTION
This resolves #44 

Before this for every multiplication you created the context. which is a very hungry operation (cpu, memory etc).

Instead we're creating a context only once and keep using that.
this context is thread safe. you can pass it around however you want.
the only constraint are:

There is no promise about the exact memory size and representation, meaning that you cannot save it to disk and reload later.
no one should try and modify it's memory(not a problem in rust)