### PR TITLE
Upgrade to ring 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ ecc = []
 
 [dependencies]
 rand = "0.6"
-ring = "0.13.5"
+ring = "0.16"
 serde = "1.0"
 serde_derive = "1.0"
 merkle = "1.10.0"
@@ -54,7 +54,7 @@ git = "https://github.com/KZen-networks/rust-gmp"
 optional = true
 
 [dependencies.secp256k1]
-version = "0.14.0"
+version = "0.15.0"
 features = ["serde"]
 optional = true
 

--- a/src/cryptographic_primitives/hashing/hmac_sha512.rs
+++ b/src/cryptographic_primitives/hashing/hmac_sha512.rs
@@ -9,15 +9,14 @@ use BigInt;
 
 use super::traits::KeyedHash;
 use arithmetic::traits::Converter;
-use ring::{digest, hmac};
+use ring::hmac;
 use zeroize::Zeroize;
 pub struct HMacSha512;
 
 impl KeyedHash for HMacSha512 {
     fn create_hmac(key: &BigInt, data: &[&BigInt]) -> BigInt {
         let mut key_bytes: Vec<u8> = key.into();
-        let mut s_ctx =
-            hmac::SigningContext::with_key(&hmac::SigningKey::new(&digest::SHA512, &key_bytes));
+        let mut s_ctx = hmac::Context::with_key(&hmac::Key::new(hmac::HMAC_SHA512, &key_bytes));
 
         for value in data {
             s_ctx.update(&BigInt::to_vec(value));

--- a/src/cryptographic_primitives/hashing/merkle_tree.rs
+++ b/src/cryptographic_primitives/hashing/merkle_tree.rs
@@ -22,7 +22,7 @@ pub struct MT256 {
 impl MT256 {
     pub fn create_tree(vec: &[GE]) -> MT256 {
         let digest = Context::new(&SHA256);
-        let tree = MerkleTree::from_vec(digest.algorithm, vec.to_vec());
+        let tree = MerkleTree::from_vec(digest.algorithm(), vec.to_vec());
         MT256 { tree }
     }
 


### PR DESCRIPTION
This requires upgrading secp256k1 as well, because otherwise they have conflicting dependendencies no the cc crate.