### PR TITLE
Upgrade to 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "curv"
 version = "0.1.0"
+edition = "2018"
 
 
 [lib]

--- a/examples/diffie_hellman_key_exchange.rs
+++ b/examples/diffie_hellman_key_exchange.rs
@@ -1,5 +1,3 @@
-extern crate curv;
-
 /// Diffie Hellman Key Exchange:
 /// TO RUN:
 /// cargo run --example diffie_hellman_key_exchange --features CURVE_NAME

--- a/examples/pedersen_commitment.rs
+++ b/examples/pedersen_commitment.rs
@@ -1,5 +1,3 @@
-extern crate curv;
-
 use curv::BigInt;
 
 /// Pedesen Commitment:

--- a/examples/proof_of_knowledge_of_dlog.rs
+++ b/examples/proof_of_knowledge_of_dlog.rs
@@ -1,5 +1,3 @@
-extern crate curv;
-
 /// Sigma protocol for proof of knowledge of discrete log
 /// TO RUN:
 /// cargo run --example proof_of_knowledge_of_dlog --features CURVE_NAME

--- a/examples/verifiable_secret_sharing.rs
+++ b/examples/verifiable_secret_sharing.rs
@@ -1,5 +1,3 @@
-extern crate curv;
-
 /// secret_sharing_3_out_of_5
 /// Feldman VSS, based on  Paul Feldman. 1987. A practical scheme for non-interactive verifiable secret sharing.
 /// In Foundations of Computer Science, 1987., 28th Annual Symposium on.IEEE, 427–43

--- a/src/arithmetic/big_gmp.rs
+++ b/src/arithmetic/big_gmp.rs
@@ -1,5 +1,3 @@
-#![cfg(feature="rust-gmp")]
-
 /*
     Curv
 
@@ -16,12 +14,12 @@
     @license GPL-3.0+ <https://github.com/KZen-networks/curv/blob/master/LICENSE>
 */
 
-use super::gmp::mpz::Mpz;
 use super::rand::rngs::OsRng;
 use super::rand::RngCore;
 use super::traits::{
     BitManipulation, ConvertFrom, Converter, Modulo, NumberTests, Samplable, ZeroizeBN, EGCD,
 };
+use gmp::mpz::Mpz;
 
 use std::borrow::Borrow;
 use std::ptr;

--- a/src/arithmetic/mod.rs
+++ b/src/arithmetic/mod.rs
@@ -14,11 +14,10 @@
     @license GPL-3.0+ <https://github.com/KZen-networks/cryptography-utils/blob/master/LICENSE>
 */
 
-#[cfg(feature = "rust-gmp")]
-extern crate gmp;
-extern crate rand;
+use rand;
 
 const HEX_RADIX: u8 = 16;
 
+#[cfg(feature = "rust-gmp")]
 pub mod big_gmp;
 pub mod traits;

--- a/src/arithmetic/traits.rs
+++ b/src/arithmetic/traits.rs
@@ -42,8 +42,8 @@ pub trait Samplable {
 }
 
 pub trait NumberTests {
-    fn is_zero(&Self) -> bool;
-    fn is_even(&Self) -> bool;
+    fn is_zero(_: &Self) -> bool;
+    fn is_even(_: &Self) -> bool;
     fn is_negative(me: &Self) -> bool;
 }
 
@@ -60,6 +60,6 @@ pub trait BitManipulation {
 }
 
 pub trait ConvertFrom<T> {
-    fn _from(&T) -> Self;
+    fn _from(_: &T) -> Self;
 }
 //use std::ops::{Add, Div, Mul, Neg, Rem, Shr, Sub};

--- a/src/cryptographic_primitives/commitments/hash_commitment.rs
+++ b/src/cryptographic_primitives/commitments/hash_commitment.rs
@@ -10,11 +10,11 @@
 /// r is 256bit blinding factor, m is the commited value
 pub struct HashCommitment;
 
-use BigInt;
+use crate::BigInt;
 
 use super::traits::Commitment;
 use super::SECURITY_BITS;
-use arithmetic::traits::Samplable;
+use crate::arithmetic::traits::Samplable;
 use sha3::{Digest, Sha3_256};
 //TODO:  using the function with BigInt's as input instead of string's makes it impossible to commit to empty message or use empty randomness
 impl Commitment<BigInt> for HashCommitment {
@@ -45,9 +45,9 @@ mod tests {
     use super::Commitment;
     use super::HashCommitment;
     use super::SECURITY_BITS;
-    use arithmetic::traits::Samplable;
+    use crate::arithmetic::traits::Samplable;
+    use crate::BigInt;
     use sha3::{Digest, Sha3_256};
-    use BigInt;
 
     #[test]
     fn test_bit_length_create_commitment() {

--- a/src/cryptographic_primitives/commitments/pedersen_commitment.rs
+++ b/src/cryptographic_primitives/commitments/pedersen_commitment.rs
@@ -7,10 +7,10 @@
 
 use super::traits::Commitment;
 use super::SECURITY_BITS;
-use arithmetic::traits::Samplable;
+use crate::arithmetic::traits::Samplable;
 
-use elliptic::curves::traits::*;
-use {BigInt, FE, GE};
+use crate::elliptic::curves::traits::*;
+use crate::{BigInt, FE, GE};
 
 /// compute c = mG + rH
 /// where m is the commited value, G is the group generator,

--- a/src/cryptographic_primitives/commitments/traits.rs
+++ b/src/cryptographic_primitives/commitments/traits.rs
@@ -5,7 +5,7 @@
     License MIT: https://github.com/KZen-networks/curv/blob/master/LICENSE
 */
 
-use BigInt;
+use crate::BigInt;
 
 pub trait Commitment<T> {
     fn create_commitment_with_user_defined_randomness(

--- a/src/cryptographic_primitives/hashing/blake2b512.rs
+++ b/src/cryptographic_primitives/hashing/blake2b512.rs
@@ -4,10 +4,10 @@
     (https://github.com/KZen-networks/curv)
     License MIT: https://github.com/KZen-networks/curv/blob/master/LICENSE
 */
-use arithmetic::traits::Converter;
+use crate::arithmetic::traits::Converter;
+use crate::elliptic::curves::traits::{ECPoint, ECScalar};
+use crate::{BigInt, FE, GE};
 use blake2b_simd::Params;
-use elliptic::curves::traits::{ECPoint, ECScalar};
-use {BigInt, FE, GE};
 
 pub struct Blake;
 
@@ -38,10 +38,10 @@ impl Blake {
 #[cfg(test)]
 mod tests {
     use super::Blake;
-    use elliptic::curves::traits::ECPoint;
-    use elliptic::curves::traits::ECScalar;
-    use BigInt;
-    use GE;
+    use crate::elliptic::curves::traits::ECPoint;
+    use crate::elliptic::curves::traits::ECScalar;
+    use crate::BigInt;
+    use crate::GE;
 
     #[test]
     // Very basic test here, TODO: suggest better testing

--- a/src/cryptographic_primitives/hashing/hash_sha256.rs
+++ b/src/cryptographic_primitives/hashing/hash_sha256.rs
@@ -6,14 +6,14 @@
 */
 
 use super::traits::Hash;
-use arithmetic::traits::Converter;
+use crate::arithmetic::traits::Converter;
+use crate::elliptic::curves::traits::{ECPoint, ECScalar};
 use crypto::digest::Digest;
 use crypto::sha2::Sha256;
-use elliptic::curves::traits::{ECPoint, ECScalar};
 use hex::decode;
 
-use BigInt;
-use {FE, GE};
+use crate::BigInt;
+use crate::{FE, GE};
 
 pub struct HSha256;
 
@@ -49,10 +49,10 @@ impl Hash for HSha256 {
 mod tests {
     use super::HSha256;
     use super::Hash;
-    use elliptic::curves::traits::ECPoint;
-    use elliptic::curves::traits::ECScalar;
-    use BigInt;
-    use GE;
+    use crate::elliptic::curves::traits::ECPoint;
+    use crate::elliptic::curves::traits::ECScalar;
+    use crate::BigInt;
+    use crate::GE;
 
     #[test]
     // Very basic test here, TODO: suggest better testing

--- a/src/cryptographic_primitives/hashing/hash_sha512.rs
+++ b/src/cryptographic_primitives/hashing/hash_sha512.rs
@@ -6,14 +6,14 @@
 */
 
 use super::traits::Hash;
-use arithmetic::traits::Converter;
+use crate::arithmetic::traits::Converter;
+use crate::elliptic::curves::traits::{ECPoint, ECScalar};
 use crypto::digest::Digest;
 use crypto::sha2::Sha512;
-use elliptic::curves::traits::{ECPoint, ECScalar};
 use hex::decode;
 
-use BigInt;
-use {FE, GE};
+use crate::BigInt;
+use crate::{FE, GE};
 
 pub struct HSha512;
 
@@ -49,10 +49,10 @@ impl Hash for HSha512 {
 mod tests {
     use super::HSha512;
     use super::Hash;
-    use elliptic::curves::traits::ECPoint;
-    use elliptic::curves::traits::ECScalar;
-    use BigInt;
-    use GE;
+    use crate::elliptic::curves::traits::ECPoint;
+    use crate::elliptic::curves::traits::ECScalar;
+    use crate::BigInt;
+    use crate::GE;
 
     #[test]
     // Very basic test here, TODO: suggest better testing

--- a/src/cryptographic_primitives/hashing/hmac_sha512.rs
+++ b/src/cryptographic_primitives/hashing/hmac_sha512.rs
@@ -5,10 +5,10 @@
     License MIT: https://github.com/KZen-networks/curv/blob/master/LICENSE
 */
 
-use BigInt;
+use crate::BigInt;
 
 use super::traits::KeyedHash;
-use arithmetic::traits::Converter;
+use crate::arithmetic::traits::Converter;
 
 use crypto::hmac::Hmac;
 use crypto::mac::Mac;
@@ -37,9 +37,9 @@ impl KeyedHash for HMacSha512 {
 mod tests {
 
     use super::HMacSha512;
-    use arithmetic::traits::Samplable;
-    use cryptographic_primitives::hashing::traits::KeyedHash;
-    use BigInt;
+    use crate::arithmetic::traits::Samplable;
+    use crate::cryptographic_primitives::hashing::traits::KeyedHash;
+    use crate::BigInt;
 
     #[test]
     fn create_hmac_test() {

--- a/src/cryptographic_primitives/hashing/merkle_tree.rs
+++ b/src/cryptographic_primitives/hashing/merkle_tree.rs
@@ -8,8 +8,8 @@
 use crypto::sha3::Sha3;
 use merkle::{MerkleTree, Proof};
 
-use elliptic::curves::traits::ECPoint;
-use GE;
+use crate::elliptic::curves::traits::ECPoint;
+use crate::GE;
 /*
 pub struct MT256<'a> {
     tree: MerkleTree<GE>,
@@ -58,9 +58,9 @@ impl MT256 {
 
 #[cfg(test)]
 mod tests {
-    use cryptographic_primitives::hashing::merkle_tree::MT256;
-    use elliptic::curves::traits::ECPoint;
-    use GE;
+    use crate::cryptographic_primitives::hashing::merkle_tree::MT256;
+    use crate::elliptic::curves::traits::ECPoint;
+    use crate::GE;
     #[test]
     fn test_mt_functionality_four_leaves() {
         let ge1: GE = ECPoint::generator();

--- a/src/cryptographic_primitives/hashing/traits.rs
+++ b/src/cryptographic_primitives/hashing/traits.rs
@@ -5,8 +5,8 @@
     License MIT: https://github.com/KZen-networks/curv/blob/master/LICENSE
 */
 
-use BigInt;
-use {FE, GE};
+use crate::BigInt;
+use crate::{FE, GE};
 
 pub trait Hash {
     fn create_hash(big_ints: &[&BigInt]) -> BigInt;

--- a/src/cryptographic_primitives/proofs/sigma_correct_homomorphic_elgamal_enc.rs
+++ b/src/cryptographic_primitives/proofs/sigma_correct_homomorphic_elgamal_enc.rs
@@ -7,12 +7,12 @@
 */
 
 use super::ProofError;
-use cryptographic_primitives::hashing::hash_sha256::HSha256;
-use cryptographic_primitives::hashing::traits::Hash;
-use elliptic::curves::traits::*;
+use crate::cryptographic_primitives::hashing::hash_sha256::HSha256;
+use crate::cryptographic_primitives::hashing::traits::Hash;
+use crate::elliptic::curves::traits::*;
+use crate::FE;
+use crate::GE;
 use zeroize::Zeroize;
-use FE;
-use GE;
 
 /// This is a proof of knowledge that a pair of group elements {D, E}
 /// form a valid homomorphic ElGamal encryption (”in the exponent”) using public key Y .
@@ -81,8 +81,8 @@ impl HomoELGamalProof {
 
 #[cfg(test)]
 mod tests {
-    use cryptographic_primitives::proofs::sigma_correct_homomorphic_elgamal_enc::*;
-    use {FE, GE};
+    use crate::cryptographic_primitives::proofs::sigma_correct_homomorphic_elgamal_enc::*;
+    use crate::{FE, GE};
 
     #[test]
     fn test_correct_general_homo_elgamal() {

--- a/src/cryptographic_primitives/proofs/sigma_correct_homomorphic_elgamal_encryption_of_dlog.rs
+++ b/src/cryptographic_primitives/proofs/sigma_correct_homomorphic_elgamal_encryption_of_dlog.rs
@@ -7,12 +7,12 @@
 */
 
 use super::ProofError;
-use cryptographic_primitives::hashing::hash_sha256::HSha256;
-use cryptographic_primitives::hashing::traits::Hash;
-use elliptic::curves::traits::*;
+use crate::cryptographic_primitives::hashing::hash_sha256::HSha256;
+use crate::cryptographic_primitives::hashing::traits::Hash;
+use crate::elliptic::curves::traits::*;
+use crate::FE;
+use crate::GE;
 use zeroize::Zeroize;
-use FE;
-use GE;
 
 /// This is a proof of knowledge that a pair of group elements {D, E}
 /// form a valid homomorphic ElGamal encryption (”in the exponent”) using public key Y .
@@ -84,8 +84,8 @@ impl HomoELGamalDlogProof {
 
 #[cfg(test)]
 mod tests {
-    use cryptographic_primitives::proofs::sigma_correct_homomorphic_elgamal_encryption_of_dlog::*;
-    use {FE, GE};
+    use crate::cryptographic_primitives::proofs::sigma_correct_homomorphic_elgamal_encryption_of_dlog::*;
+    use crate::{FE, GE};
 
     #[test]
     fn test_correct_homo_elgamal() {

--- a/src/cryptographic_primitives/proofs/sigma_dlog.rs
+++ b/src/cryptographic_primitives/proofs/sigma_dlog.rs
@@ -6,13 +6,13 @@
 */
 
 use super::ProofError;
-use FE;
-use GE;
+use crate::FE;
+use crate::GE;
 
-use elliptic::curves::traits::*;
+use crate::elliptic::curves::traits::*;
 
-use cryptographic_primitives::hashing::hash_sha256::HSha256;
-use cryptographic_primitives::hashing::traits::Hash;
+use crate::cryptographic_primitives::hashing::hash_sha256::HSha256;
+use crate::cryptographic_primitives::hashing::traits::Hash;
 use zeroize::Zeroize;
 
 /// This is implementation of Schnorr's identification protocol for elliptic curve groups or a
@@ -90,8 +90,8 @@ impl ProveDLog for DLogProof {
 
 #[cfg(test)]
 mod tests {
-    use cryptographic_primitives::proofs::sigma_dlog::*;
-    use FE;
+    use crate::cryptographic_primitives::proofs::sigma_dlog::*;
+    use crate::FE;
 
     #[test]
     fn test_dlog_proof() {

--- a/src/cryptographic_primitives/proofs/sigma_ec_ddh.rs
+++ b/src/cryptographic_primitives/proofs/sigma_ec_ddh.rs
@@ -6,11 +6,11 @@
 */
 
 use super::ProofError;
-use cryptographic_primitives::hashing::hash_sha256::HSha256;
-use cryptographic_primitives::hashing::traits::Hash;
-use elliptic::curves::traits::*;
+use crate::cryptographic_primitives::hashing::hash_sha256::HSha256;
+use crate::cryptographic_primitives::hashing::traits::Hash;
+use crate::elliptic::curves::traits::*;
+use crate::{FE, GE};
 use zeroize::Zeroize;
-use {FE, GE};
 
 /// This protocol is the elliptic curve form of the protocol from :
 ///  D. Chaum, T. P. Pedersen. Transferred cash grows in size. In Advances in Cryptology, EUROCRYPT , volume 658 of Lecture Notes in Computer Science, pages 390 - 407, 1993.
@@ -81,9 +81,9 @@ impl NISigmaProof<ECDDHProof, ECDDHWitness, ECDDHStatement> for ECDDHProof {
 
 #[cfg(test)]
 mod tests {
-    use cryptographic_primitives::proofs::sigma_ec_ddh::*;
-    use elliptic::curves::traits::{ECPoint, ECScalar};
-    use {FE, GE};
+    use crate::cryptographic_primitives::proofs::sigma_ec_ddh::*;
+    use crate::elliptic::curves::traits::{ECPoint, ECScalar};
+    use crate::{FE, GE};
 
     #[test]
     fn test_ecddh_proof() {

--- a/src/cryptographic_primitives/proofs/sigma_valid_pedersen.rs
+++ b/src/cryptographic_primitives/proofs/sigma_valid_pedersen.rs
@@ -6,13 +6,13 @@
 */
 
 use super::ProofError;
-use cryptographic_primitives::commitments::pedersen_commitment::PedersenCommitment;
-use cryptographic_primitives::commitments::traits::Commitment;
-use cryptographic_primitives::hashing::hash_sha256::HSha256;
-use cryptographic_primitives::hashing::traits::Hash;
-use elliptic::curves::traits::*;
+use crate::cryptographic_primitives::commitments::pedersen_commitment::PedersenCommitment;
+use crate::cryptographic_primitives::commitments::traits::Commitment;
+use crate::cryptographic_primitives::hashing::hash_sha256::HSha256;
+use crate::cryptographic_primitives::hashing::traits::Hash;
+use crate::elliptic::curves::traits::*;
+use crate::{FE, GE};
 use zeroize::Zeroize;
-use {FE, GE};
 
 /// protocol for proving that Pedersen commitment c was constructed correctly which is the same as
 /// proof of knowledge of (m,r) such that c = mG + rH.
@@ -109,8 +109,8 @@ impl ProvePederesen for PedersenProof {
 
 #[cfg(test)]
 mod tests {
-    use cryptographic_primitives::proofs::sigma_valid_pedersen::*;
-    use FE;
+    use crate::cryptographic_primitives::proofs::sigma_valid_pedersen::*;
+    use crate::FE;
 
     #[test]
     fn test_pedersen_proof() {

--- a/src/cryptographic_primitives/proofs/sigma_valid_pedersen_blind.rs
+++ b/src/cryptographic_primitives/proofs/sigma_valid_pedersen_blind.rs
@@ -6,14 +6,14 @@
 */
 
 use super::ProofError;
-use cryptographic_primitives::commitments::pedersen_commitment::PedersenCommitment;
-use cryptographic_primitives::commitments::traits::Commitment;
-use cryptographic_primitives::hashing::hash_sha256::HSha256;
-use cryptographic_primitives::hashing::traits::Hash;
-use elliptic::curves::traits::*;
+use crate::cryptographic_primitives::commitments::pedersen_commitment::PedersenCommitment;
+use crate::cryptographic_primitives::commitments::traits::Commitment;
+use crate::cryptographic_primitives::hashing::hash_sha256::HSha256;
+use crate::cryptographic_primitives::hashing::traits::Hash;
+use crate::elliptic::curves::traits::*;
 
+use crate::{FE, GE};
 use zeroize::Zeroize;
-use {FE, GE};
 
 /// protocol for proving that Pedersen commitment c was constructed correctly which is the same as
 /// proof of knowledge of (r) such that c = mG + rH.
@@ -99,8 +99,8 @@ impl ProvePederesenBlind for PedersenBlindingProof {
 
 #[cfg(test)]
 mod tests {
-    use cryptographic_primitives::proofs::sigma_valid_pedersen_blind::*;
-    use FE;
+    use crate::cryptographic_primitives::proofs::sigma_valid_pedersen_blind::*;
+    use crate::FE;
 
     #[test]
     fn test_pedersen_blind_proof() {

--- a/src/cryptographic_primitives/secret_sharing/feldman_vss.rs
+++ b/src/cryptographic_primitives/secret_sharing/feldman_vss.rs
@@ -6,11 +6,11 @@
     License MIT: <https://github.com/KZen-networks/curv/blob/master/LICENSE>
 */
 
-use elliptic::curves::traits::*;
-use BigInt;
-use ErrorSS::{self, VerifyShareError};
-use FE;
-use GE;
+use crate::elliptic::curves::traits::*;
+use crate::BigInt;
+use crate::ErrorSS::{self, VerifyShareError};
+use crate::FE;
+use crate::GE;
 
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub struct ShamirSecretSharing {
@@ -238,8 +238,8 @@ impl VerifiableSS {
 
 #[cfg(test)]
 mod tests {
-    use cryptographic_primitives::secret_sharing::feldman_vss::*;
-    use {FE, GE};
+    use crate::cryptographic_primitives::secret_sharing::feldman_vss::*;
+    use crate::{FE, GE};
 
     #[test]
     fn test_secret_sharing_3_out_of_5_at_indices() {

--- a/src/cryptographic_primitives/twoparty/coin_flip_optimal_rounds.rs
+++ b/src/cryptographic_primitives/twoparty/coin_flip_optimal_rounds.rs
@@ -5,12 +5,12 @@
     License MIT: <https://github.com/KZen-networks/curv/blob/master/LICENSE>
 */
 
-use cryptographic_primitives::proofs::sigma_valid_pedersen::PedersenProof;
-use cryptographic_primitives::proofs::sigma_valid_pedersen::ProvePederesen;
-use cryptographic_primitives::proofs::sigma_valid_pedersen_blind::PedersenBlindingProof;
-use cryptographic_primitives::proofs::sigma_valid_pedersen_blind::ProvePederesenBlind;
-use elliptic::curves::traits::*;
-use {FE, GE};
+use crate::cryptographic_primitives::proofs::sigma_valid_pedersen::PedersenProof;
+use crate::cryptographic_primitives::proofs::sigma_valid_pedersen::ProvePederesen;
+use crate::cryptographic_primitives::proofs::sigma_valid_pedersen_blind::PedersenBlindingProof;
+use crate::cryptographic_primitives::proofs::sigma_valid_pedersen_blind::ProvePederesenBlind;
+use crate::elliptic::curves::traits::*;
+use crate::{FE, GE};
 
 /// based on How To Simulate It – A Tutorial on the Simulation
 /// Proof Technique. protocol 7.3: Multiple coin tossing. which provide simulatble constant round
@@ -72,7 +72,7 @@ pub fn finalize(proof: &PedersenBlindingProof, party2seed: &FE, party1comm: &GE)
 
 #[cfg(test)]
 mod tests {
-    use cryptographic_primitives::twoparty::coin_flip_optimal_rounds::*;
+    use crate::cryptographic_primitives::twoparty::coin_flip_optimal_rounds::*;
     #[test]
     pub fn test_coin_toss() {
         let (party1_first_message, m1, r1) = Party1FirstMessage::commit();

--- a/src/cryptographic_primitives/twoparty/dh_key_exchange.rs
+++ b/src/cryptographic_primitives/twoparty/dh_key_exchange.rs
@@ -9,9 +9,9 @@
 /// Bob chooses at random a secret "b" and sends to Alice B = bG.
 /// Both parties can compute a joint secret: C =aB = bA = abG which cannot be computed by
 /// a man in the middle attacker.
-use elliptic::curves::traits::*;
-use FE;
-use GE;
+use crate::elliptic::curves::traits::*;
+use crate::FE;
+use crate::GE;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct EcKeyPair {
@@ -87,10 +87,10 @@ pub fn compute_pubkey(local_share: &EcKeyPair, other_share_public_share: &GE) ->
 
 #[cfg(test)]
 mod tests {
-    use cryptographic_primitives::twoparty::dh_key_exchange::*;
-    use elliptic::curves::traits::ECScalar;
-    use BigInt;
-    use {FE, GE};
+    use crate::cryptographic_primitives::twoparty::dh_key_exchange::*;
+    use crate::elliptic::curves::traits::ECScalar;
+    use crate::BigInt;
+    use crate::{FE, GE};
 
     #[test]
     fn test_dh_key_exchange_random_shares() {

--- a/src/cryptographic_primitives/twoparty/dh_key_exchange_variant_with_pok_comm.rs
+++ b/src/cryptographic_primitives/twoparty/dh_key_exchange_variant_with_pok_comm.rs
@@ -13,15 +13,15 @@
 /// The variant below is to protect not only from man in the middle but also from malicious
 /// Alice or Bob that can bias the result. The details of the protocol can be found in
 /// https://eprint.iacr.org/2017/552.pdf protocol 3.1 first 3 steps.
-use arithmetic::traits::Samplable;
-use cryptographic_primitives::commitments::hash_commitment::HashCommitment;
-use cryptographic_primitives::commitments::traits::Commitment;
-use cryptographic_primitives::proofs::sigma_dlog::*;
-use cryptographic_primitives::proofs::ProofError;
-use elliptic::curves::traits::*;
-use BigInt;
-use FE;
-use GE;
+use crate::arithmetic::traits::Samplable;
+use crate::cryptographic_primitives::commitments::hash_commitment::HashCommitment;
+use crate::cryptographic_primitives::commitments::traits::Commitment;
+use crate::cryptographic_primitives::proofs::sigma_dlog::*;
+use crate::cryptographic_primitives::proofs::ProofError;
+use crate::elliptic::curves::traits::*;
+use crate::BigInt;
+use crate::FE;
+use crate::GE;
 
 const SECURITY_BITS: usize = 256;
 
@@ -234,7 +234,7 @@ pub fn compute_pubkey(local_share: &EcKeyPair, other_share_public_share: &GE) ->
 
 #[cfg(test)]
 mod tests {
-    use cryptographic_primitives::twoparty::dh_key_exchange_variant_with_pok_comm::*;
+    use crate::cryptographic_primitives::twoparty::dh_key_exchange_variant_with_pok_comm::*;
 
     #[test]
     fn test_dh_key_exchange() {

--- a/src/elliptic/curves/curve_jubjub.rs
+++ b/src/elliptic/curves/curve_jubjub.rs
@@ -9,16 +9,16 @@
 use std::fmt::Debug;
 use std::str;
 pub const SECRET_KEY_SIZE: usize = 64;
-use super::pairing::bls12_381::Bls12;
-use super::sapling_crypto::jubjub::*;
-use super::sapling_crypto::jubjub::{edwards, fs::Fs, JubjubBls12, PrimeOrder, Unknown};
 use super::traits::{ECPoint, ECScalar};
-use arithmetic::traits::Converter;
+use crate::arithmetic::traits::Converter;
+use crate::cryptographic_primitives::hashing::hash_sha256::HSha256;
+use crate::cryptographic_primitives::hashing::traits::Hash;
 use crypto::digest::Digest;
 use crypto::sha3::Sha3;
-use cryptographic_primitives::hashing::hash_sha256::HSha256;
-use cryptographic_primitives::hashing::traits::Hash;
 use merkle::Hashable;
+use pairing::bls12_381::Bls12;
+use sapling_crypto::jubjub::*;
+use sapling_crypto::jubjub::{edwards, fs::Fs, JubjubBls12, PrimeOrder, Unknown};
 
 use serde::de;
 use serde::de::{MapAccess, Visitor};
@@ -27,18 +27,18 @@ use serde::ser::{Serialize, Serializer};
 use serde::{Deserialize, Deserializer};
 use std::fmt;
 use std::ops::{Add, Mul};
-use BigInt;
-use ErrorKey::{self, InvalidPublicKey};
 pub type SK = Fs;
 // we will take advantage of the fact that jubjub lib provides a uninque type for prime order sub group
 pub type PK = edwards::Point<Bls12, PrimeOrder>; // specific type for element in the prime order sub group
 pub type PKu = edwards::Point<Bls12, Unknown>; // special type for general point
-use super::pairing::Field;
-use super::pairing::PrimeField;
-use super::pairing::PrimeFieldRepr;
-use super::sapling_crypto::jubjub::JubjubParams;
-use super::sapling_crypto::jubjub::ToUniform;
-use arithmetic::traits::{Modulo, Samplable};
+use crate::arithmetic::traits::{Modulo, Samplable};
+use crate::BigInt;
+use crate::ErrorKey::{self, InvalidPublicKey};
+use pairing::Field;
+use pairing::PrimeField;
+use pairing::PrimeFieldRepr;
+use sapling_crypto::jubjub::JubjubParams;
+use sapling_crypto::jubjub::ToUniform;
 use std::ptr;
 use std::sync::atomic;
 use zeroize::Zeroize;
@@ -527,12 +527,12 @@ impl<'de> Visitor<'de> for RistrettoCurvPointVisitor {
 #[cfg(test)]
 mod tests {
     use super::JubjubPoint;
-    use arithmetic::traits::Modulo;
-    use elliptic::curves::traits::ECPoint;
-    use elliptic::curves::traits::ECScalar;
-    extern crate serde_json;
-    use BigInt;
-    use {FE, GE};
+    use crate::arithmetic::traits::Modulo;
+    use crate::elliptic::curves::traits::ECPoint;
+    use crate::elliptic::curves::traits::ECScalar;
+    use crate::BigInt;
+    use crate::{FE, GE};
+    use serde_json;
 
     #[test]
     fn test_serdes_pk() {

--- a/src/elliptic/curves/curve_ristretto.rs
+++ b/src/elliptic/curves/curve_ristretto.rs
@@ -6,15 +6,17 @@
     License MIT: <https://github.com/KZen-networks/curv/blob/master/LICENSE>
 */
 
-use super::curve25519_dalek::constants::BASEPOINT_ORDER;
-use super::curve25519_dalek::constants::RISTRETTO_BASEPOINT_COMPRESSED;
-use super::curve25519_dalek::ristretto::CompressedRistretto;
-use super::curve25519_dalek::scalar::Scalar;
-use super::rand::thread_rng;
 use super::traits::{ECPoint, ECScalar};
-use arithmetic::traits::Converter;
-use cryptographic_primitives::hashing::hash_sha256::HSha256;
-use cryptographic_primitives::hashing::traits::Hash;
+use crate::arithmetic::traits::Converter;
+use crate::cryptographic_primitives::hashing::hash_sha256::HSha256;
+use crate::cryptographic_primitives::hashing::traits::Hash;
+use crate::BigInt;
+use crate::ErrorKey::{self, InvalidPublicKey};
+use curve25519_dalek::constants::BASEPOINT_ORDER;
+use curve25519_dalek::constants::RISTRETTO_BASEPOINT_COMPRESSED;
+use curve25519_dalek::ristretto::CompressedRistretto;
+use curve25519_dalek::scalar::Scalar;
+use rand::thread_rng;
 use serde::de;
 use serde::de::{MapAccess, Visitor};
 use serde::ser::SerializeStruct;
@@ -23,8 +25,6 @@ use serde::{Deserialize, Deserializer};
 use std::fmt;
 use std::ops::{Add, Mul};
 use std::str;
-use BigInt;
-use ErrorKey::{self, InvalidPublicKey};
 pub const SECRET_KEY_SIZE: usize = 32;
 pub const COOR_BYTE_SIZE: usize = 32;
 pub const NUM_OF_COORDINATES: usize = 4;
@@ -468,13 +468,13 @@ impl<'de> Visitor<'de> for RistrettoCurvPointVisitor {
 mod tests {
 
     use super::RistrettoCurvPoint;
-    use arithmetic::traits::Converter;
-    use arithmetic::traits::Modulo;
-    use elliptic::curves::traits::ECPoint;
-    use elliptic::curves::traits::ECScalar;
-    extern crate serde_json;
-    use BigInt;
-    use {FE, GE};
+    use crate::arithmetic::traits::Converter;
+    use crate::arithmetic::traits::Modulo;
+    use crate::elliptic::curves::traits::ECPoint;
+    use crate::elliptic::curves::traits::ECScalar;
+    use crate::BigInt;
+    use crate::{FE, GE};
+    use serde_json;
 
     #[test]
     fn test_serdes_pk() {

--- a/src/elliptic/curves/ed25519.rs
+++ b/src/elliptic/curves/ed25519.rs
@@ -11,13 +11,12 @@
 use std::fmt::Debug;
 use std::str;
 pub const TWO_TIMES_SECRET_KEY_SIZE: usize = 64;
-use super::cryptoxide::curve25519::*;
 use super::traits::{ECPoint, ECScalar};
-use arithmetic::traits::Converter;
+use crate::arithmetic::traits::Converter;
+use crate::cryptographic_primitives::hashing::hash_sha256::HSha256;
+use crate::cryptographic_primitives::hashing::traits::Hash;
 use crypto::digest::Digest;
 use crypto::sha3::Sha3;
-use cryptographic_primitives::hashing::hash_sha256::HSha256;
-use cryptographic_primitives::hashing::traits::Hash;
 use merkle::Hashable;
 use serde::de;
 use serde::de::{MapAccess, Visitor};
@@ -26,11 +25,12 @@ use serde::ser::{Serialize, Serializer};
 use serde::{Deserialize, Deserializer};
 use std::fmt;
 use std::ops::{Add, Mul};
-use BigInt;
-use ErrorKey::{self, InvalidPublicKey};
 pub type SK = Fe;
 pub type PK = GeP3;
-use arithmetic::traits::{Modulo, Samplable};
+use crate::arithmetic::traits::{Modulo, Samplable};
+use crate::BigInt;
+use crate::ErrorKey::{self, InvalidPublicKey};
+use cryptoxide::curve25519::*;
 use std::ptr;
 use std::sync::atomic;
 use zeroize::Zeroize;
@@ -575,12 +575,12 @@ pub fn expmod(b: &BigInt, e: &BigInt, m: &BigInt) -> BigInt {
 #[cfg(test)]
 mod tests {
     use super::Ed25519Point;
-    use arithmetic::traits::Modulo;
-    use elliptic::curves::traits::ECPoint;
-    use elliptic::curves::traits::ECScalar;
-    extern crate serde_json;
-    use BigInt;
-    use {FE, GE};
+    use crate::arithmetic::traits::Modulo;
+    use crate::elliptic::curves::traits::ECPoint;
+    use crate::elliptic::curves::traits::ECScalar;
+    use crate::BigInt;
+    use crate::{FE, GE};
+    use serde_json;
 
     #[test]
     fn test_serdes_pk() {

--- a/src/elliptic/curves/mod.rs
+++ b/src/elliptic/curves/mod.rs
@@ -5,19 +5,6 @@
     License MIT: <https://github.com/KZen-networks/curv/blob/master/LICENSE>
 */
 
-extern crate rand;
-
-#[cfg(feature = "cryptoxide")]
-extern crate cryptoxide;
-#[cfg(feature = "curve25519-dalek")]
-extern crate curve25519_dalek;
-#[cfg(feature = "pairing")]
-extern crate pairing;
-#[cfg(feature = "sapling-crypto")]
-extern crate sapling_crypto;
-#[cfg(feature = "secp256k1")]
-extern crate secp256k1;
-
 #[cfg(feature = "ec_jubjub")]
 pub mod curve_jubjub;
 #[cfg(feature = "ec_ristretto")]

--- a/src/elliptic/curves/secp256_k1.rs
+++ b/src/elliptic/curves/secp256_k1.rs
@@ -16,18 +16,20 @@
 // The Public Key codec: Point <> SecretKey
 //
 
-use super::rand::{thread_rng, Rng};
-use super::secp256k1::constants::{
-    CURVE_ORDER, GENERATOR_X, GENERATOR_Y, SECRET_KEY_SIZE, UNCOMPRESSED_PUBLIC_KEY_SIZE,
-};
-use super::secp256k1::{PublicKey, Secp256k1, SecretKey, VerifyOnly};
 use super::traits::{ECPoint, ECScalar};
-use arithmetic::traits::{Converter, Modulo};
+use crate::arithmetic::traits::{Converter, Modulo};
+use crate::cryptographic_primitives::hashing::hash_sha256::HSha256;
+use crate::cryptographic_primitives::hashing::traits::Hash;
+use crate::BigInt;
+use crate::ErrorKey;
 use crypto::digest::Digest;
 use crypto::sha3::Sha3;
-use cryptographic_primitives::hashing::hash_sha256::HSha256;
-use cryptographic_primitives::hashing::traits::Hash;
 use merkle::Hashable;
+use rand::{thread_rng, Rng};
+use secp256k1::constants::{
+    CURVE_ORDER, GENERATOR_X, GENERATOR_Y, SECRET_KEY_SIZE, UNCOMPRESSED_PUBLIC_KEY_SIZE,
+};
+use secp256k1::{PublicKey, Secp256k1, SecretKey, VerifyOnly};
 use serde::de;
 use serde::de::{MapAccess, Visitor};
 use serde::ser::SerializeStruct;
@@ -38,8 +40,6 @@ use std::ops::{Add, Mul};
 use std::ptr;
 use std::sync::{atomic, Once};
 use zeroize::Zeroize;
-use BigInt;
-use ErrorKey;
 
 pub type SK = SecretKey;
 pub type PK = PublicKey;
@@ -580,13 +580,13 @@ mod tests {
     use super::BigInt;
     use super::Secp256k1Point;
     use super::Secp256k1Scalar;
-    use arithmetic::traits::Converter;
-    use arithmetic::traits::Modulo;
-    use cryptographic_primitives::hashing::hash_sha256::HSha256;
-    use cryptographic_primitives::hashing::traits::Hash;
-    use elliptic::curves::traits::ECPoint;
-    use elliptic::curves::traits::ECScalar;
-    extern crate serde_json;
+    use crate::arithmetic::traits::Converter;
+    use crate::arithmetic::traits::Modulo;
+    use crate::cryptographic_primitives::hashing::hash_sha256::HSha256;
+    use crate::cryptographic_primitives::hashing::traits::Hash;
+    use crate::elliptic::curves::traits::ECPoint;
+    use crate::elliptic::curves::traits::ECScalar;
+    use serde_json;
 
     #[test]
     fn serialize_sk() {
@@ -648,8 +648,8 @@ mod tests {
         assert_eq!(des_pk.ge, pk.ge);
     }
 
-    use elliptic::curves::secp256_k1::{FE, GE};
-    use ErrorKey;
+    use crate::elliptic::curves::secp256_k1::{FE, GE};
+    use crate::ErrorKey;
 
     #[test]
     fn test_serdes_pk() {

--- a/src/elliptic/curves/traits.rs
+++ b/src/elliptic/curves/traits.rs
@@ -5,8 +5,8 @@
     License MIT: <https://github.com/KZen-networks/curv/blob/master/LICENSE>
 */
 
-use BigInt;
-use ErrorKey;
+use crate::BigInt;
+use crate::ErrorKey;
 
 pub trait ECScalar<SK> {
     fn new_random() -> Self;

--- a/src/elliptic/mod.rs
+++ b/src/elliptic/mod.rs
@@ -5,6 +5,4 @@
     License MIT: <https://github.com/KZen-networks/curv/blob/master/LICENSE>
 */
 
-extern crate gmp;
-
 pub mod curves;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,23 +7,16 @@
 
 #[macro_use]
 extern crate serde_derive;
-extern crate blake2b_simd;
-extern crate crypto;
-extern crate hex;
-extern crate merkle;
-extern crate serde;
-extern crate sha3;
-extern crate zeroize;
 
 #[cfg(feature = "ecc")]
 pub mod elliptic;
 
 #[cfg(feature = "ec_secp256k1")]
 mod secp256k1instance {
-    pub use elliptic::curves::secp256_k1::FE;
-    pub use elliptic::curves::secp256_k1::GE;
-    pub use elliptic::curves::secp256_k1::PK;
-    pub use elliptic::curves::secp256_k1::SK;
+    pub use crate::elliptic::curves::secp256_k1::FE;
+    pub use crate::elliptic::curves::secp256_k1::GE;
+    pub use crate::elliptic::curves::secp256_k1::PK;
+    pub use crate::elliptic::curves::secp256_k1::SK;
 }
 
 #[cfg(feature = "ec_secp256k1")]
@@ -31,10 +24,10 @@ pub use self::secp256k1instance::*;
 
 #[cfg(feature = "ec_ristretto")]
 mod curveristrettoinstance {
-    pub use elliptic::curves::curve_ristretto::FE;
-    pub use elliptic::curves::curve_ristretto::GE;
-    pub use elliptic::curves::curve_ristretto::PK;
-    pub use elliptic::curves::curve_ristretto::SK;
+    pub use crate::elliptic::curves::curve_ristretto::FE;
+    pub use crate::elliptic::curves::curve_ristretto::GE;
+    pub use crate::elliptic::curves::curve_ristretto::PK;
+    pub use crate::elliptic::curves::curve_ristretto::SK;
 }
 
 #[cfg(feature = "ec_ristretto")]
@@ -42,10 +35,10 @@ pub use self::curveristrettoinstance::*;
 
 #[cfg(feature = "ec_ed25519")]
 mod ed25519instance {
-    pub use elliptic::curves::ed25519::FE;
-    pub use elliptic::curves::ed25519::GE;
-    pub use elliptic::curves::ed25519::PK;
-    pub use elliptic::curves::ed25519::SK;
+    pub use crate::elliptic::curves::ed25519::FE;
+    pub use crate::elliptic::curves::ed25519::GE;
+    pub use crate::elliptic::curves::ed25519::PK;
+    pub use crate::elliptic::curves::ed25519::SK;
 }
 
 #[cfg(feature = "ec_ed25519")]
@@ -53,10 +46,10 @@ pub use self::ed25519instance::*;
 
 #[cfg(feature = "ec_jubjub")]
 mod jubjubinstance {
-    pub use elliptic::curves::curve_jubjub::FE;
-    pub use elliptic::curves::curve_jubjub::GE;
-    pub use elliptic::curves::curve_jubjub::PK;
-    pub use elliptic::curves::curve_jubjub::SK;
+    pub use crate::elliptic::curves::curve_jubjub::FE;
+    pub use crate::elliptic::curves::curve_jubjub::GE;
+    pub use crate::elliptic::curves::curve_jubjub::PK;
+    pub use crate::elliptic::curves::curve_jubjub::SK;
 }
 
 #[cfg(feature = "ec_jubjub")]
@@ -65,7 +58,7 @@ pub use self::jubjubinstance::*;
 #[cfg(feature = "rust-gmp")]
 pub mod arithmetic;
 #[cfg(feature = "rust-gmp")]
-pub use arithmetic::big_gmp::BigInt;
+pub use crate::arithmetic::big_gmp::BigInt;
 
 #[cfg(feature = "ecc")]
 pub mod cryptographic_primitives;


### PR DESCRIPTION
This is nice because, besides in general keeping up with the language/ecosystem, you don't need to deal with the feature flags for `extern crate` statements.