### PR TITLE
Add hash test vectors

### DIFF
--- a/src/cryptographic_primitives/hashing/hash_sha256.rs
+++ b/src/cryptographic_primitives/hashing/hash_sha256.rs
@@ -47,12 +47,41 @@ mod tests {
     use GE;
 
     #[test]
-    // Very basic test here, TODO: suggest better testing
     fn create_hash_test() {
         HSha256::create_hash(&vec![]);
 
         let result = HSha256::create_hash(&vec![&BigInt::one(), &BigInt::zero()]);
         assert!(result > BigInt::zero());
+    }
+
+    #[test]
+    // Test Vectors taken from:
+    // https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program/secure-hashing#shavs
+    fn hash_vector_test() {
+        // Empty Message
+        let result: BigInt = HSha256::create_hash(&vec![]);
+        assert_eq!(
+            result.to_str_radix(16),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+
+        // 256 bit message
+        let result: BigInt = HSha256::create_hash(&vec![&BigInt::from_str_radix(
+            "09fc1accc230a205e4a208e64a8f204291f581a12756392da4b8c0cf5ef02b95",
+            16,
+        )
+        .unwrap()]);
+        assert_eq!(
+            result.to_str_radix(16),
+            "4f44c1c7fbebb6f9601829f3897bfd650c56fa07844be76489076356ac1886a4"
+        );
+
+        // 512 bit message
+        let result: BigInt = HSha256::create_hash(&vec![&BigInt::from_str_radix("5a86b737eaea8ee976a0a24da63e7ed7eefad18a101c1211e2b3650c5187c2a8a650547208251f6d4237e661c7bf4c77f335390394c37fa1a9f9be836ac28509", 16).unwrap()]);
+        assert_eq!(
+            result.to_str_radix(16),
+            "42e61e174fbb3897d6dd6cef3dd2802fe67b331953b06114a65c772859dfc1aa"
+        );
     }
 
     #[test]

--- a/src/cryptographic_primitives/hashing/hash_sha256.rs
+++ b/src/cryptographic_primitives/hashing/hash_sha256.rs
@@ -47,14 +47,6 @@ mod tests {
     use GE;
 
     #[test]
-    fn create_hash_test() {
-        HSha256::create_hash(&vec![]);
-
-        let result = HSha256::create_hash(&vec![&BigInt::one(), &BigInt::zero()]);
-        assert!(result > BigInt::zero());
-    }
-
-    #[test]
     // Test Vectors taken from:
     // https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program/secure-hashing#shavs
     fn hash_vector_test() {
@@ -71,6 +63,16 @@ mod tests {
             16,
         )
         .unwrap()]);
+        assert_eq!(
+            result.to_str_radix(16),
+            "4f44c1c7fbebb6f9601829f3897bfd650c56fa07844be76489076356ac1886a4"
+        );
+
+        // 2x128 bit messages
+        let result: BigInt = HSha256::create_hash(&vec![
+            &BigInt::from_str_radix("09fc1accc230a205e4a208e64a8f2042", 16).unwrap(),
+            &BigInt::from_str_radix("91f581a12756392da4b8c0cf5ef02b95", 16).unwrap(),
+        ]);
         assert_eq!(
             result.to_str_radix(16),
             "4f44c1c7fbebb6f9601829f3897bfd650c56fa07844be76489076356ac1886a4"

--- a/src/cryptographic_primitives/hashing/hash_sha512.rs
+++ b/src/cryptographic_primitives/hashing/hash_sha512.rs
@@ -47,12 +47,41 @@ mod tests {
     use GE;
 
     #[test]
-    // Very basic test here, TODO: suggest better testing
     fn create_hash_test() {
         HSha512::create_hash(&vec![]);
 
         let result = HSha512::create_hash(&vec![&BigInt::one(), &BigInt::zero()]);
         assert!(result > BigInt::zero());
+    }
+
+    #[test]
+    // Test Vectors taken from:
+    // https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program/secure-hashing#shavs
+    fn hash_vector_test() {
+        // Empty message
+        let result: BigInt = HSha512::create_hash(&vec![]);
+        assert_eq!(
+            result.to_str_radix(16),
+            "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+        );
+
+        // 512 bit message
+        let result: BigInt = HSha512::create_hash(&vec![&BigInt::from_str_radix(
+            "c1ca70ae1279ba0b918157558b4920d6b7fba8a06be515170f202fafd36fb7f79d69fad745dba6150568db1e2b728504113eeac34f527fc82f2200b462ecbf5d",
+            16,
+        )
+        .unwrap()]);
+        assert_eq!(
+            result.to_str_radix(16),
+            "46e46623912b3932b8d662ab42583423843206301b58bf20ab6d76fd47f1cbbcf421df536ecd7e56db5354e7e0f98822d2129c197f6f0f222b8ec5231f3967d"
+        );
+
+        // 1024 bit message
+        let result: BigInt = HSha512::create_hash(&vec![&BigInt::from_str_radix("fd2203e467574e834ab07c9097ae164532f24be1eb5d88f1af7748ceff0d2c67a21f4e4097f9d3bb4e9fbf97186e0db6db0100230a52b453d421f8ab9c9a6043aa3295ea20d2f06a2f37470d8a99075f1b8a8336f6228cf08b5942fc1fb4299c7d2480e8e82bce175540bdfad7752bc95b577f229515394f3ae5cec870a4b2f8", 16).unwrap()]);
+        assert_eq!(
+            result.to_str_radix(16),
+            "a21b1077d52b27ac545af63b32746c6e3c51cb0cb9f281eb9f3580a6d4996d5c9917d2a6e484627a9d5a06fa1b25327a9d710e027387fc3e07d7c4d14c6086cc"
+        );
     }
 
     #[test]

--- a/src/cryptographic_primitives/hashing/hash_sha512.rs
+++ b/src/cryptographic_primitives/hashing/hash_sha512.rs
@@ -47,14 +47,6 @@ mod tests {
     use GE;
 
     #[test]
-    fn create_hash_test() {
-        HSha512::create_hash(&vec![]);
-
-        let result = HSha512::create_hash(&vec![&BigInt::one(), &BigInt::zero()]);
-        assert!(result > BigInt::zero());
-    }
-
-    #[test]
     // Test Vectors taken from:
     // https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program/secure-hashing#shavs
     fn hash_vector_test() {
@@ -63,6 +55,24 @@ mod tests {
         assert_eq!(
             result.to_str_radix(16),
             "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+        );
+
+        // 2x256 bit message
+        let result: BigInt = HSha512::create_hash(&vec![
+            &BigInt::from_str_radix(
+                "c1ca70ae1279ba0b918157558b4920d6b7fba8a06be515170f202fafd36fb7f7",
+                16,
+            )
+            .unwrap(),
+            &BigInt::from_str_radix(
+                "9d69fad745dba6150568db1e2b728504113eeac34f527fc82f2200b462ecbf5d",
+                16,
+            )
+            .unwrap(),
+        ]);
+        assert_eq!(
+            result.to_str_radix(16),
+            "46e46623912b3932b8d662ab42583423843206301b58bf20ab6d76fd47f1cbbcf421df536ecd7e56db5354e7e0f98822d2129c197f6f0f222b8ec5231f3967d"
         );
 
         // 512 bit message


### PR DESCRIPTION
Added test vectors from here: https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program/secure-hashing#shavs

Tested empty message, same size message and longer message