### PR TITLE
secp point to bytes fixed 65bytes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curv"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2018"
 
 [lib]

--- a/src/cryptographic_primitives/secret_sharing/feldman_vss.rs
+++ b/src/cryptographic_primitives/secret_sharing/feldman_vss.rs
@@ -176,13 +176,13 @@ impl VerifiableSS {
         tail.fold(head.clone(), |acc, x| acc.add(&x.get_element()))
     }
 
-    pub fn validate_share(&self, secret_share: &FE, index: usize) -> Result<(), (ErrorSS)> {
+    pub fn validate_share(&self, secret_share: &FE, index: usize) -> Result<(), ErrorSS> {
         let G: GE = ECPoint::generator();
         let ss_point = G * secret_share;
         self.validate_share_public(&ss_point, index)
     }
 
-    pub fn validate_share_public(&self, ss_point: &GE, index: usize) -> Result<(), (ErrorSS)> {
+    pub fn validate_share_public(&self, ss_point: &GE, index: usize) -> Result<(), ErrorSS> {
         let comm_to_point = self.get_point_commitment(index);
         if *ss_point == comm_to_point {
             Ok(())

--- a/src/elliptic/curves/secp256_k1.rs
+++ b/src/elliptic/curves/secp256_k1.rs
@@ -380,7 +380,6 @@ impl ECPoint<PK, SK> for Secp256k1Point {
     fn pk_to_key_slice(&self) -> Vec<u8> {
         let mut v = vec![4 as u8];
         let x_vec = BigInt::to_vec(&self.x_coor().unwrap());
-
         let y_vec = BigInt::to_vec(&self.y_coor().unwrap());
 
         let mut raw_x: Vec<u8> = Vec::new();
@@ -803,8 +802,6 @@ mod tests {
             assert!(key_slice[0].clone() == 4);
 
             let rg_prime: GE = ECPoint::from_bytes(&key_slice[1..65]).unwrap();
-            println!("TEST2");
-
             assert_eq!(rg_prime.get_element(), rg.get_element());
         }
     }

--- a/src/elliptic/curves/secp256_k1.rs
+++ b/src/elliptic/curves/secp256_k1.rs
@@ -379,9 +379,20 @@ impl ECPoint<PK, SK> for Secp256k1Point {
     }
     fn pk_to_key_slice(&self) -> Vec<u8> {
         let mut v = vec![4 as u8];
+        let x_vec = BigInt::to_vec(&self.x_coor().unwrap());
 
-        v.extend(BigInt::to_vec(&self.x_coor().unwrap()));
-        v.extend(BigInt::to_vec(&self.y_coor().unwrap()));
+        let y_vec = BigInt::to_vec(&self.y_coor().unwrap());
+
+        let mut raw_x: Vec<u8> = Vec::new();
+        let mut raw_y: Vec<u8> = Vec::new();
+        raw_x.extend(vec![0u8; 32 - x_vec.len()]);
+        raw_x.extend(x_vec);
+
+        raw_y.extend(vec![0u8; 32 - y_vec.len()]);
+        raw_y.extend(y_vec);
+
+        v.extend(raw_x);
+        v.extend(raw_y);
         v
     }
 
@@ -779,5 +790,22 @@ mod tests {
         let c1 = a.mul(&b.get_element());
         let c2 = a * b;
         assert_eq!(c1.get_element(), c2.get_element());
+    }
+
+    #[test]
+    fn test_pk_to_key_slice() {
+        for _ in 1..200 {
+            let r = FE::new_random();
+            let rg = GE::generator() * &r;
+            let key_slice = rg.pk_to_key_slice();
+
+            assert!(key_slice.len() == 65);
+            assert!(key_slice[0].clone() == 4);
+
+            let rg_prime: GE = ECPoint::from_bytes(&key_slice[1..65]).unwrap();
+            println!("TEST2");
+
+            assert_eq!(rg_prime.get_element(), rg.get_element());
+        }
     }
 }


### PR DESCRIPTION
This fix is making sure that a call to `pk_to_key_slice` for secp256k1 curve will always return 65 bytes in the format `0x04` + 32 bytes `x` + 32 bytes `y`. 
Prior to the fix if `x` coordinate was with zero  MSByte the result would have been 64 bytes of wrong point 