### PR TITLE
Update `hmac`, `digest`, `sha2`,`sha3` dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,22 @@
 
 ## v0.8.0-rc3
 * Fix point subtraction. Bug was introduced in `v0.8.0-rc1`. [#127]
+* Add `Polynomial::lagrange_basis` function [#130]
+* Katex <> Docs integration [#131] \
+  Allows using KaTeX in documentation comments. Math formulas will be properly rendered on docs.rs.
+* LDEI proof minor improvements [#133] \
+  Adds missing implementations of Clone and serialization traits.
+* Update `hmac`, `digest`, `sha2`,`sha3` dependencies [#134] \
+  `hmac`: `v0.7.1` → `v0.11` \
+  `digest`: `v0.8.1` → `v0.9` \
+  `sha2`: `v0.8.0` → `v0.9` \
+  `sha3`: `v0.8.2` → `v0.9`
 
 [#127]: https://github.com/ZenGo-X/curv/pull/127
+[#130]: https://github.com/ZenGo-X/curv/pull/130
+[#131]: https://github.com/ZenGo-X/curv/pull/131
+[#133]: https://github.com/ZenGo-X/curv/pull/133
+[#134]: https://github.com/ZenGo-X/curv/pull/134
 
 ## v0.8.0-rc2
 * Remove dependency on `ring_algorithm` crate [#125], [#124]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ crate-type = ["lib"]
 blake2b_simd = "0.5.7"
 cryptoxide = "0.1.2"
 curve25519-dalek = "3"
-digest = "0.8.1"
+digest = "0.9"
 ff-zeroize = "0.6.3"
 hex = { version = "0.4", features = ["serde"] }
-hmac = "0.7.1"
+hmac = "0.11"
 thiserror = "1"
 merkle-sha3 = "^0.1"
 lazy_static = "1.4"
@@ -34,8 +34,9 @@ rust-crypto = "^0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
 serde_derive = "1.0"
-sha2 = "0.8.0"
-sha3 = "0.8.2"
+sha2 = "0.9"
+sha3 = "0.9"
+old_sha2 = { package = "sha2", version = "0.8" }
 zeroize = "1"
 
 rust-gmp-kzen = { version = "0.5", features = ["serde_support"], optional = true }

--- a/src/cryptographic_primitives/commitments/hash_commitment.rs
+++ b/src/cryptographic_primitives/commitments/hash_commitment.rs
@@ -24,10 +24,10 @@ impl Commitment<BigInt> for HashCommitment {
     ) -> BigInt {
         let mut digest = Sha3_256::new();
         let bytes_message = message.to_bytes();
-        digest.input(&bytes_message);
+        digest.update(&bytes_message);
         let bytes_blinding_factor = blinding_factor.to_bytes();
-        digest.input(&bytes_blinding_factor);
-        BigInt::from_bytes(digest.result().as_ref())
+        digest.update(&bytes_blinding_factor);
+        BigInt::from_bytes(digest.finalize().as_ref())
     }
 
     fn create_commitment(message: &BigInt) -> (BigInt, BigInt) {
@@ -101,10 +101,10 @@ mod tests {
             &BigInt::zero(),
         );
         let message2 = message.to_bytes();
-        digest.input(&message2);
+        digest.update(&message2);
         let bytes_blinding_factor = &BigInt::zero().to_bytes();
-        digest.input(&bytes_blinding_factor);
-        let hash_result = BigInt::from_bytes(digest.result().as_ref());
+        digest.update(&bytes_blinding_factor);
+        let hash_result = BigInt::from_bytes(digest.finalize().as_ref());
         assert_eq!(&commitment, &hash_result);
     }
 }

--- a/src/cryptographic_primitives/hashing/hash_sha256.rs
+++ b/src/cryptographic_primitives/hashing/hash_sha256.rs
@@ -24,28 +24,28 @@ impl Hash for HSha256 {
         let mut hasher = Sha256::new();
 
         for value in big_ints {
-            hasher.input(&BigInt::to_bytes(value));
+            hasher.update(&BigInt::to_bytes(value));
         }
 
-        let result_hex = hasher.result();
+        let result_hex = hasher.finalize();
         BigInt::from_bytes(&result_hex[..])
     }
 
     fn create_hash_from_ge<E: Curve>(ge_vec: &[&Point<E>]) -> Scalar<E> {
         let mut hasher = Sha256::new();
         for value in ge_vec {
-            hasher.input(&value.to_bytes(false)[..]);
+            hasher.update(&value.to_bytes(false)[..]);
         }
 
-        let result_hex = hasher.result();
+        let result_hex = hasher.finalize();
         let result = BigInt::from_bytes(&result_hex[..]);
         Scalar::from(&result)
     }
 
     fn create_hash_from_slice(byte_slice: &[u8]) -> BigInt {
         let mut hasher = Sha256::new();
-        hasher.input(byte_slice);
-        let result_hex = hasher.result();
+        hasher.update(byte_slice);
+        let result_hex = hasher.finalize();
         BigInt::from_bytes(&result_hex[..])
     }
 }
@@ -68,8 +68,8 @@ mod tests {
 
         let result = HSha256::create_hash(&[&big_int0, &big_int1]).to_hex();
         let mut hasher = Sha256::new();
-        hasher.input(&message);
-        let result2 = hex::encode(hasher.result());
+        hasher.update(&message);
+        let result2 = hex::encode(hasher.finalize());
         assert_eq!(result, result2);
     }
 

--- a/src/cryptographic_primitives/hashing/hash_sha512.rs
+++ b/src/cryptographic_primitives/hashing/hash_sha512.rs
@@ -24,28 +24,28 @@ impl Hash for HSha512 {
         let mut hasher = Sha512::new();
 
         for value in big_ints {
-            hasher.input(&BigInt::to_bytes(value));
+            hasher.update(&BigInt::to_bytes(value));
         }
 
-        let result_hex = hasher.result();
+        let result_hex = hasher.finalize();
         BigInt::from_bytes(&result_hex[..])
     }
 
     fn create_hash_from_ge<E: Curve>(ge_vec: &[&Point<E>]) -> Scalar<E> {
         let mut hasher = Sha512::new();
         for value in ge_vec {
-            hasher.input(&value.to_bytes(false)[..]);
+            hasher.update(&value.to_bytes(false)[..]);
         }
 
-        let result_hex = hasher.result();
+        let result_hex = hasher.finalize();
         let result = BigInt::from_bytes(&result_hex[..]);
         Scalar::from(&result)
     }
 
     fn create_hash_from_slice(byte_slice: &[u8]) -> BigInt {
         let mut hasher = Sha512::new();
-        hasher.input(byte_slice);
-        let result_hex = hasher.result();
+        hasher.update(byte_slice);
+        let result_hex = hasher.finalize();
         BigInt::from_bytes(&result_hex[..])
     }
 }

--- a/src/elliptic/curves/bls12_381/g1.rs
+++ b/src/elliptic/curves/bls12_381/g1.rs
@@ -13,7 +13,6 @@ use pairing_plus::hash_to_curve::HashToCurve;
 use pairing_plus::hash_to_field::ExpandMsgXmd;
 use pairing_plus::{CurveAffine, CurveProjective, Engine};
 use pairing_plus::{EncodedPoint, SubgroupCheck};
-use sha2::Sha256;
 use zeroize::Zeroize;
 
 use crate::arithmetic::traits::*;
@@ -246,7 +245,7 @@ impl G1Point {
     /// [xmd]: https://www.ietf.org/id/draft-irtf-cfrg-hash-to-curve-10.html#name-expand_message_xmd-2
     pub fn hash_to_curve(message: &[u8]) -> Self {
         let cs = &[1u8];
-        let point = <G1 as HashToCurve<ExpandMsgXmd<Sha256>>>::hash_to_curve(message, cs);
+        let point = <G1 as HashToCurve<ExpandMsgXmd<old_sha2::Sha256>>>::hash_to_curve(message, cs);
         G1Point {
             purpose: "hash_to_curve",
             ge: point.into_affine(),
@@ -283,7 +282,6 @@ mod tests {
     use pairing_plus::hash_to_curve::HashToCurve;
     use pairing_plus::hash_to_field::ExpandMsgXmd;
     use pairing_plus::{CurveProjective, SubgroupCheck};
-    use sha2::Sha256;
 
     use super::{ECPoint, GE1};
 
@@ -292,7 +290,7 @@ mod tests {
         // Generate base_point2
         let cs = &[1u8];
         let msg = &[1u8];
-        let point = <G1 as HashToCurve<ExpandMsgXmd<Sha256>>>::hash_to_curve(msg, cs).into_affine();
+        let point = <G1 as HashToCurve<ExpandMsgXmd<old_sha2::Sha256>>>::hash_to_curve(msg, cs).into_affine();
         assert!(point.in_subgroup());
 
         // Print in uncompressed form

--- a/src/elliptic/curves/bls12_381/g2.rs
+++ b/src/elliptic/curves/bls12_381/g2.rs
@@ -13,7 +13,6 @@ use pairing_plus::hash_to_curve::HashToCurve;
 use pairing_plus::hash_to_field::ExpandMsgXmd;
 use pairing_plus::{CurveAffine, CurveProjective, Engine};
 use pairing_plus::{EncodedPoint, SubgroupCheck};
-use sha2::Sha256;
 use zeroize::Zeroize;
 
 use crate::arithmetic::*;
@@ -253,7 +252,7 @@ impl G2Point {
     /// [xmd]: https://www.ietf.org/id/draft-irtf-cfrg-hash-to-curve-10.html#name-expand_message_xmd-2
     pub fn hash_to_curve(message: &[u8]) -> Self {
         let cs = &[1u8];
-        let point = <G2 as HashToCurve<ExpandMsgXmd<Sha256>>>::hash_to_curve(message, cs);
+        let point = <G2 as HashToCurve<ExpandMsgXmd<old_sha2::Sha256>>>::hash_to_curve(message, cs);
         G2Point {
             purpose: "hash_to_curve",
             ge: point.into_affine(),
@@ -293,7 +292,7 @@ mod tests {
         // Generate base_point2
         let cs = &[1u8];
         let msg = &[1u8];
-        let point = <G2 as HashToCurve<ExpandMsgXmd<Sha256>>>::hash_to_curve(msg, cs).into_affine();
+        let point = <G2 as HashToCurve<ExpandMsgXmd<old_sha2::Sha256>>>::hash_to_curve(msg, cs).into_affine();
         assert!(point.in_subgroup());
 
         // Print in uncompressed form


### PR DESCRIPTION
Updates dependencies:
* `hmac`: `v0.7.1` → `v0.11` 
* `digest`: `v0.8.1` → `v0.9` 
* `sha2`: `v0.8.0` → `v0.9` 
* `sha3`: `v0.8.2` → `v0.9`

We keep additional dependency on older `sha2 v0.8.0`, it's required for `pairing_plus` compatibility as it still depends on older `digest v0.8.1`

Fixes #132 