### PR TITLE
Use curve25519-dalek instead of cryptoxide

### DIFF
--- a/src/elliptic/curves/ed25519.rs
+++ b/src/elliptic/curves/ed25519.rs
@@ -264,7 +264,6 @@ impl ECPoint for Ed25519Point {
         &BASE_POINT2
     }
 
-
     fn from_coords(x: &BigInt, y: &BigInt) -> Result<Self, NotOnCurve> {
         let is_odd = x.is_odd();
         let expected_x = xrecover(y, is_odd);

--- a/src/elliptic/curves/p256.rs
+++ b/src/elliptic/curves/p256.rs
@@ -11,8 +11,8 @@ use p256::{AffinePoint, EncodedPoint, FieldBytes, ProjectivePoint, Scalar};
 
 use generic_array::GenericArray;
 use rand::{thread_rng, Rng};
-use zeroize::Zeroize;
 use serde::{Deserialize, Serialize};
+use zeroize::Zeroize;
 
 use super::traits::{ECPoint, ECScalar};
 use crate::arithmetic::traits::*;

--- a/src/elliptic/curves/secp256_k1.rs
+++ b/src/elliptic/curves/secp256_k1.rs
@@ -26,8 +26,8 @@ use secp256k1::constants::{
     self, GENERATOR_X, GENERATOR_Y, SECRET_KEY_SIZE, UNCOMPRESSED_PUBLIC_KEY_SIZE,
 };
 use secp256k1::{PublicKey, SecretKey, SECP256K1};
-use zeroize::{Zeroize, Zeroizing};
 use serde::{Deserialize, Serialize};
+use zeroize::{Zeroize, Zeroizing};
 
 use crate::arithmetic::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,5 +44,3 @@ impl fmt::Display for ErrorSS {
     }
 }
 impl error::Error for ErrorSS {}
-
-


### PR DESCRIPTION
We currently depend on both of them, (curve25519-dalek for ristretto and cryptoxide for ed25519). and the dalek one is considered very robust and safe.
This also simplify a lot of the code there (and will probably even improve performance)

Maybe we should add test vectors to make sure that this doesn't change the behavior in any way.