### PR TITLE
Update secp256k1 dependency, remove rand_legacy.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ num-traits = "0.2"
 num-integer = "0.1"
 pairing-plus = "0.19"
 rand = "0.7"
-rand_legacy = { package = "rand", version = "0.6" }
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
 serde_derive = "1.0"
@@ -43,7 +42,7 @@ rust-gmp-kzen = { version = "0.5", features = ["serde_support"], optional = true
 num-bigint = { version = "0.4", features = ["serde"], optional = true }
 
 [dependencies.secp256k1]
-version = "0.20"
+version = "0.24"
 features = ["serde", "rand-std", "global-context"]
 
 [dependencies.p256]


### PR DESCRIPTION
Paves the way to upgrade to `rand:0.8` by updating the `secp256k1` dependency to latest and removing the obsolete `rand_legacy` dependency.