### PR TITLE
Fix minor documentation typos

### DIFF
--- a/src/elliptic/curves/bls12_381/g2.rs
+++ b/src/elliptic/curves/bls12_381/g2.rs
@@ -246,7 +246,7 @@ impl ECPoint for G2Point {
 }
 
 impl G2Point {
-    /// Converts message to G1 point.
+    /// Converts message to G2 point.
     ///
     /// Uses [expand_message_xmd][xmd] based on sha256.
     ///

--- a/src/elliptic/curves/traits.rs
+++ b/src/elliptic/curves/traits.rs
@@ -182,7 +182,7 @@ pub trait ECPoint: Zeroize + Clone + PartialEq + fmt::Debug + Sync + Send + 'sta
     /// For curves with co-factor ≠ 1, following check must be carried out:
     ///
     /// ```text
-    /// P ≠ 0 ∧ qP ≠ 0
+    /// P ≠ 0 ∧ qP = 0
     /// ```
     ///
     /// For curves with co-factor = 1, the check above can be reduced to: `P ≠ 0`.


### PR DESCRIPTION
* If `P` is order `q` then `qP = 0`.
* Mis-copied comment still says G1 instead of G2.

Fixes #167 