### PR TITLE
Fix compiler error for wasm32-unknown-unknown

### DIFF
--- a/src/arithmetic/big_native/primes.rs
+++ b/src/arithmetic/big_native/primes.rs
@@ -503,7 +503,7 @@ fn is_bit_set(x: &BigUint, i: usize) -> bool {
 fn gen_biguint_below<R: Rng>(r: &mut R, upper: &BigUint) -> BigUint {
     loop {
         let bits = upper.bits();
-        let bytes = bits.div_ceil(8);
+        let bytes = bits.div_ceil(&8u64);
         let mut buf = vec![0u8; bytes as usize];
         r.fill_bytes(&mut buf);
 

--- a/src/arithmetic/big_native/primes.rs
+++ b/src/arithmetic/big_native/primes.rs
@@ -503,7 +503,7 @@ fn is_bit_set(x: &BigUint, i: usize) -> bool {
 fn gen_biguint_below<R: Rng>(r: &mut R, upper: &BigUint) -> BigUint {
     loop {
         let bits = upper.bits();
-        let bytes = bits.div_ceil(&8);
+        let bytes = bits.div_ceil(8);
         let mut buf = vec![0u8; bytes as usize];
         r.fill_bytes(&mut buf);
 

--- a/src/cryptographic_primitives/secret_sharing/polynomial.rs
+++ b/src/cryptographic_primitives/secret_sharing/polynomial.rs
@@ -425,6 +425,6 @@ impl<E: Curve> ops::Sub for &Polynomial<E> {
             self.coefficients()[len2..].to_vec()
         };
 
-        Polynomial::from_coefficients(overlapped.chain(tail.into_iter()).collect())
+        Polynomial::from_coefficients(overlapped.chain(tail).collect())
     }
 }

--- a/src/elliptic/curves/wrappers/generator.rs
+++ b/src/elliptic/curves/wrappers/generator.rs
@@ -70,7 +70,7 @@ impl<E: Curve> Generator<E> {
 
 impl<E: Curve> Clone for Generator<E> {
     fn clone(&self) -> Self {
-        Self { _ph: PhantomData }
+        *self
     }
 }
 


### PR DESCRIPTION
When compiling `curv-kzen` on a recent nightly channel with the `num-bigint` feature I hit this error:

```
error[E0308]: mismatched types
   --> /Users/muji/.cargo/registry/src/index.crates.io-6f17d22bba15001f/curv-kzen-0.10.0/src/arithmetic/big_native/primes.rs:506:35
    |
506 |         let bytes = bits.div_ceil(&8);
    |                          -------- ^^ expected `u64`, found `&{integer}`
    |                          |
    |                          arguments to this method are incorrect
    |
note: method defined here
   --> /rustc/ca62d2c445628587660ae48013f460b08b1f5552/library/core/src/num/mod.rs:1166:5
    = note: this error originates in the macro `uint_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider removing the borrow
    |
506 -         let bytes = bits.div_ceil(&8);
506 +         let bytes = bits.div_ceil(8);
    |

For more information about this error, try `rustc --explain E0308`.
error: could not compile `curv-kzen` (lib) due to previous error
```

By removing the reference the compiler error is fixed. I am using `patch.crates-io` as a workaround for now but would be great if you could merge this tiny fix please.

Thanks 🙏 