### PR TITLE
Make GE for sec256k1 public

### DIFF
--- a/src/elliptic/curves/secp256_k1.rs
+++ b/src/elliptic/curves/secp256_k1.rs
@@ -152,8 +152,8 @@ pub struct Secp256k1Point {
     ge: Option<PK>,
 }
 
-type GE = Secp256k1Point;
-type FE = Secp256k1Scalar;
+pub type GE = Secp256k1Point;
+pub type FE = Secp256k1Scalar;
 
 impl ECScalar for Secp256k1Scalar {
     type Underlying = Option<SK>;


### PR DESCRIPTION
I think GE and FE for secp256k1 should be public interface.
GE and FE is private since commit https://github.com/ZenGo-X/curv/pull/120/commits/d8419383e64ff0be55b7558b6bfb85b54cc1ff9a .
Any reason for keeping GE and FE private?